### PR TITLE
showMenus option added

### DIFF
--- a/mjpegcanvas.js
+++ b/mjpegcanvas.js
@@ -125,7 +125,7 @@
                 mouseEnter = true;
               }, false);
               canvas.addEventListener('mouseleave', function(e) {
-                mouseEnter = true;
+                mouseEnter = false;
               }, false);
               canvas
                   .addEventListener(


### PR DESCRIPTION
showMenus option added to allow for the menus to be always visible. This addresses the issue discussed here: https://github.com/RobotWebTools/mjpegcanvasjs/issues/7
